### PR TITLE
Allow autosave during pause but only autosave when there was progress

### DIFF
--- a/src/logic/save_handler.h
+++ b/src/logic/save_handler.h
@@ -79,6 +79,7 @@ public:
 private:
 	uint32_t next_save_realtime_{0U};
 	uint32_t last_save_realtime_{0U};
+	Time next_save_min_gametime_;
 	Time last_save_gametime_;
 	bool initialized_{false};
 	bool allow_saving_{true};
@@ -90,10 +91,11 @@ private:
 
 	FileSystem::Type fs_type_{FileSystem::ZIP};
 	int32_t autosave_interval_in_ms_{kDefaultAutosaveInterval * 60 * 1000};
+	Duration autosave_gametime_interval_;
 	int32_t number_of_rolls_{5};  // For rolling file update
 	bool skip_when_inactive_{true};
 
-	void initialize(uint32_t realtime);
+	void initialize(Widelands::Game& game, uint32_t realtime);
 	bool roll_save_files(const std::string& filename, std::string* error) const;
 	bool check_next_tick(Widelands::Game& game, uint32_t realtime) const;
 };


### PR DESCRIPTION
**Type of change**
Refactoring

**Issue(s) closed**
Re https://github.com/widelands/widelands/pull/6048#pullrequestreview-1567732632

**New behavior**
1. Autosaves only happen if gametime also progressed at least half of the set autosave interval
2. But then autosaves also happen during pauses

**Possible regressions**
Autosave behaviour?