### PR TITLE
Unify portspace search code for expeditions and warships

### DIFF
--- a/src/ai/defaultai_seafaring.cc
+++ b/src/ai/defaultai_seafaring.cc
@@ -490,7 +490,7 @@ void DefaultAI::expedition_management(ShipObserver& so) {
 	if (!so.ship->exp_port_spaces().empty()) {
 
 		// we score the place (value max == 8)
-		const uint8_t spot_score = spot_scoring(so.ship->exp_port_spaces().front()) * 2;
+		const uint8_t spot_score = spot_scoring(so.ship->exp_port_spaces().back()) * 2;
 		verb_log_dbg_time(gametime, "%d: %s at %3dx%3d: PORTSPACE found, we valued it: %d\n", pn,
 		                  so.ship->get_shipname().c_str(), so.ship->get_position().x,
 		                  so.ship->get_position().y, spot_score);
@@ -498,7 +498,7 @@ void DefaultAI::expedition_management(ShipObserver& so) {
 		// we make a decision based on the score value and random
 		if (RNG::static_rand(8) < spot_score) {
 			// we build a port here
-			game().send_player_ship_construct_port(*so.ship, so.ship->exp_port_spaces().front());
+			game().send_player_ship_construct_port(*so.ship, so.ship->exp_port_spaces().back());
 			so.last_command_time = gametime;
 			so.waiting_for_command_ = false;
 

--- a/src/ai/defaultai_seafaring.cc
+++ b/src/ai/defaultai_seafaring.cc
@@ -487,10 +487,11 @@ void DefaultAI::expedition_management(ShipObserver& so) {
 
 	// if we have a port-space we can build a Port or continue exploring
 	// 1. examine to build a port (colony founding)
-	if (!so.ship->exp_port_spaces().empty()) {
+	const Widelands::Coords portspace = so.ship->current_portspace();
+	if (static_cast<bool>(portspace)) {
 
 		// we score the place (value max == 8)
-		const uint8_t spot_score = spot_scoring(so.ship->exp_port_spaces().back()) * 2;
+		const uint8_t spot_score = spot_scoring(portspace) * 2;
 		verb_log_dbg_time(gametime, "%d: %s at %3dx%3d: PORTSPACE found, we valued it: %d\n", pn,
 		                  so.ship->get_shipname().c_str(), so.ship->get_position().x,
 		                  so.ship->get_position().y, spot_score);
@@ -498,7 +499,7 @@ void DefaultAI::expedition_management(ShipObserver& so) {
 		// we make a decision based on the score value and random
 		if (RNG::static_rand(8) < spot_score) {
 			// we build a port here
-			game().send_player_ship_construct_port(*so.ship, so.ship->exp_port_spaces().back());
+			game().send_player_ship_construct_port(*so.ship, portspace);
 			so.last_command_time = gametime;
 			so.waiting_for_command_ = false;
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -62,7 +62,7 @@ constexpr unsigned kSinkAnimationDuration = 3000;
 constexpr unsigned kNearDestinationShipRadius = 4;
 constexpr unsigned kNearDestinationNoteRadius = 1;
 
-static const std::string kPortspaceIconFile = "images/wui/editor/fsel_editor_set_port_space.png";
+const std::string kPortspaceIconFile = "images/wui/editor/fsel_editor_set_port_space.png";
 
 /// Returns true if 'coords' is not blocked by immovables
 /// Trees are allowed, because we don't want spreading forests to block portspaces from expeditions

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -678,7 +678,7 @@ bool Ship::update_seen_portspaces(Game& game, const bool report_known, const boo
 			continue;
 		}
 		if (!is_suitable_portspace(mr.location())) {
-			if (get_owner()->has_detected_port_space(mr.location())) {
+			if (get_owner()->has_detected_port_space(mr.location()) != nullptr) {
 				// Update owner even if can't use currently
 				remember_detected_portspace(mr.location());
 			}  // TODO(tothxa): But what to do with enemy ports spotted first by expeditions?

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -121,8 +121,8 @@ bool Ship::can_build_port_here(const Coords& coords) const {
 	map.get_rn(fc, &c[4]);
 	map.get_brn(fc, &c[5]);
 	map.get_bln(fc, &c[6]);
-	for (const Widelands::FCoords& fc : c) {
-		if (!can_support_port(fc, BaseImmovable::NONE)) {  // check for blocking immovables
+	for (const Widelands::FCoords& fcc : c) {
+		if (!can_support_port(fcc, BaseImmovable::NONE)) {  // check for blocking immovables
 			return false;
 		}
 	}
@@ -730,7 +730,7 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 		} break;
 		case USPspResult::kInvalid: {
 			NEVER_HERE();
-		} break;
+		}
 		}
 
 		if (found_new_target) {
@@ -873,7 +873,7 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 		} break;
 		case USPspResult::kInvalid: {
 			NEVER_HERE();
-		} break;
+		}
 		}
 	} else if (ship_state_ == ShipStates::kExpeditionPortspaceFound) {
 		check_port_space_still_available(game);

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -62,7 +62,7 @@ constexpr unsigned kSinkAnimationDuration = 3000;
 constexpr unsigned kNearDestinationShipRadius = 4;
 constexpr unsigned kNearDestinationNoteRadius = 1;
 
-/// Returns true if 'coord' is not blocked by immovables
+/// Returns true if 'coords' is not blocked by immovables
 /// Trees are allowed, because we don't want spreading forests to block portspaces from expeditions
 bool can_support_port(const FCoords& coords, BaseImmovable::Size max_immo_size) {
 	BaseImmovable* baim = coords.field->get_immovable();
@@ -77,7 +77,7 @@ bool can_support_port(const FCoords& coords, BaseImmovable::Size max_immo_size) 
 
 }  // namespace
 
-/// Returns true if the ship can land and erect a port at 'coord'.
+/// Returns true if the ship can land and erect a port at 'coords'.
 bool Ship::can_build_port_here(const Coords& coords) const {
 	const PlayerNumber player_number = owner().player_number();
 	const EditorGameBase& egbase = owner().egbase();
@@ -626,8 +626,7 @@ Ship::USPspResult Ship::update_seen_portspaces(
 		return USPspResult::kInvalid;
 	}
 
-	const EditorGameBase& egbase = owner().egbase();
-	const Map& map = egbase.map();
+	const Map& map = owner().egbase().map();
 
 	USPspResult rv = USPspResult::kNoChange;
 
@@ -647,9 +646,7 @@ Ship::USPspResult Ship::update_seen_portspaces(
 	// Look for new nearby port spaces.
 	MapRegion<Area<Coords>> mr(map, Area<Coords>(get_position(), descr().vision_range()));
 	do {
-		if (!map.is_port_space(mr.location()) ||
-		    !map.is_port_space_allowed(egbase, map.get_fcoords(mr.location())) ||
-		    !is_suitable(mr.location())) {
+		if (!map.is_port_space(mr.location()) || !is_suitable(mr.location())) {
 			continue;
 		}
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -721,10 +721,16 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 			// Update display in InteractivePlayer
 			Notifications::publish(NoteShip(this, NoteShip::Action::kWaitingForCommand));
 		} break;
-		case USPspResult::kSpottedKnown:  // TODO(tothxa): This could also only send note, but that
-		                                  //   would be inconsistent with civilian expeditions, which
-		                                  //   would be harder to use if they didn't stop. That needs
-		                                  //   some solution first.
+		case USPspResult::kSpottedKnown: {
+			// Compatibility with old behaviour: Stop the ship and send message to player.
+			//
+			// TODO(tothxa): This should also only send a note for display updating, but that would
+			//               be inconsistent with civilian expeditions, which would be harder to use
+			//               if they didn't stop. That needs some solution first.
+			send_message(game, _("Port Space"), _("Port Space Spotted"),
+			             _("A warship arrived at a known port build space."), descr().icon_filename());
+			found_new_target = true;
+		} break;
 		case USPspResult::kFoundNew: {
 			found_new_target = true;
 		} break;
@@ -865,8 +871,17 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 			// Update display in InteractivePlayer
 			Notifications::publish(NoteShip(this, NoteShip::Action::kWaitingForCommand));
 		} break;
-		case USPspResult::kSpottedKnown:  // TODO(tothxa): This could also only send note, but that
-		                                  // needs UI changes to make already known portspaces usable.
+		case USPspResult::kSpottedKnown: {
+			// Compatibility with old behaviour: Stop the ship and send message to player.
+			//
+			// TODO(tothxa): This should also only send a note for display updating, but that needs
+			//               UI changes to make already known portspaces usable.
+			send_message(game, _("Port Space"), _("Port Space Spotted"),
+			             _("An expedition ship arrived at a known port build space."),
+			             descr().icon_filename());
+			set_ship_state_and_notify(
+			   ShipStates::kExpeditionPortspaceFound, NoteShip::Action::kWaitingForCommand);
+		} break;
 		case USPspResult::kFoundNew: {
 			set_ship_state_and_notify(
 			   ShipStates::kExpeditionPortspaceFound, NoteShip::Action::kWaitingForCommand);

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -367,12 +367,23 @@ private:
 
 	PortDock* find_nearest_port(Game& game);
 
+	// Possible return values for update_seen_portspaces()
+	enum class USPspResult { kNoChange, kLostSight, kSpottedKnown, kFoundNew, kInvalid };
+
+	// Checks and remembers port spaces within the ship's vision range.
+	// Sends a message for each newly discovered port space.
+	// The highest priority event will be returned if there are multiple changes.
+	[[nodiscard]] USPspResult
+	update_seen_portspaces(Game& game,
+	                       std::function<bool(const Coords& coords)> is_suitable,
+	                       std::function<void(Game& g)> send_new_portspace_message);
 	void send_message(Game& game,
 	                  const std::string& title,
 	                  const std::string& heading,
 	                  const std::string& description,
 	                  const std::string& picture);
 	bool remember_detected_portspace(const Coords& coords);
+	[[nodiscard]] bool can_build_port_here(const Coords& coords) const;
 	[[nodiscard]] bool suited_as_invasion_portspace(const Coords& coords) const;
 
 	ShipFleet* fleet_{nullptr};

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -243,10 +243,23 @@ struct Ship : Bob {
 		return false;
 	}
 
-	/// \returns (in expedition mode only!) the list of currently seen port build spaces
-	[[nodiscard]] const std::vector<Coords>& exp_port_spaces() const {
-		assert(expedition_ != nullptr);
-		return expedition_->seen_port_buildspaces;
+	// Returns whether the ship can currently see a port space at coords that it can use to
+	// build a port or start an invasion
+	[[nodiscard]] bool sees_portspace(const Coords& coords) const {
+		if (expedition_ == nullptr || expedition_->seen_port_buildspaces.empty()) {
+			return false;
+		}
+		const std::vector<Coords>& seen = expedition_->seen_port_buildspaces;
+		return std::find(seen.begin(), seen.end(), coords) != seen.end();
+	}
+
+	// Returns the coordinates of the current primary seen port space of the ship,
+	// or the invalid coordinates if the ship cannot see any suitable port spaces.
+	[[nodiscard]] Coords current_portspace() const {
+		if (expedition_ == nullptr || expedition_->seen_port_buildspaces.empty()) {
+			return Coords::null();
+		}
+		return expedition_->seen_port_buildspaces.back();
 	}
 
 	void exp_scouting_direction(Game&, WalkingDir);

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -367,24 +367,21 @@ private:
 
 	PortDock* find_nearest_port(Game& game);
 
-	// Possible return values for update_seen_portspaces()
-	enum class USPspResult { kNoChange, kLostSight, kSpottedKnown, kFoundNew, kInvalid };
-
 	// Checks and remembers port spaces within the ship's vision range.
-	// Sends a message for each newly discovered port space.
-	// The highest priority event will be returned if there are multiple changes.
-	[[nodiscard]] USPspResult
-	update_seen_portspaces(Game& game,
-	                       std::function<bool(const Coords& coords)> is_suitable,
-	                       std::function<void(Game& g)> send_new_portspace_message);
+	// Sends a message for each newly spotted port space.
+	// Returns whether any port spaces are newly spotted.
+	bool update_seen_portspaces(Game& game);
+
+	bool remember_detected_portspace(const Coords& coords);
+	[[nodiscard]] bool can_build_port_here(const Coords& coords) const;
+	[[nodiscard]] bool suited_as_invasion_portspace(const Coords& coords) const;
 	void send_message(Game& game,
 	                  const std::string& title,
 	                  const std::string& heading,
 	                  const std::string& description,
 	                  const std::string& picture);
-	bool remember_detected_portspace(const Coords& coords);
-	[[nodiscard]] bool can_build_port_here(const Coords& coords) const;
-	[[nodiscard]] bool suited_as_invasion_portspace(const Coords& coords) const;
+	void send_new_portspace_message(Game& g);
+	void send_known_portspace_message(Game& g);
 
 	ShipFleet* fleet_{nullptr};
 	Economy* ware_economy_{nullptr};

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -368,13 +368,21 @@ private:
 	PortDock* find_nearest_port(Game& game);
 
 	// Checks and remembers port spaces within the ship's vision range.
-	// Sends a message for each newly spotted port space.
-	// Returns whether any port spaces are newly spotted.
-	bool update_seen_portspaces(Game& game);
+	// If report_known is true, then sends message on all newly spotted port spaces, otherwise only
+	// on newly discovered port spaces.
+	// If stop_on_report is true, then also stops the ship when a port space is reported.
+	// Returns whether the ship was stopped.
+	bool update_seen_portspaces(Game& game, bool report_known = true, bool stop_on_report = true);
 
+	// Stores coords as a DetectedPortSpace or updates owner if already known.
+	// Returns true if the port space was previously not known.
 	bool remember_detected_portspace(const Coords& coords);
+
+	// Uses the applicable check of the below two functions according to ship type.
+	[[nodiscard]] bool is_suitable_portspace(const Coords& coords) const;
 	[[nodiscard]] bool can_build_port_here(const Coords& coords) const;
 	[[nodiscard]] bool suited_as_invasion_portspace(const Coords& coords) const;
+
 	void send_message(Game& game,
 	                  const std::string& title,
 	                  const std::string& heading,

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -7402,7 +7402,7 @@ int LuaShip::build_colonization_port(lua_State* L) {
 	Widelands::Ship* ship = get(L, egbase);
 	if (ship->get_ship_state() == Widelands::ShipStates::kExpeditionPortspaceFound) {
 		if (upcast(Widelands::Game, game, &egbase)) {
-			game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().front());
+			game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().back());
 			return 1;
 		}
 	}

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -7402,7 +7402,9 @@ int LuaShip::build_colonization_port(lua_State* L) {
 	Widelands::Ship* ship = get(L, egbase);
 	if (ship->get_ship_state() == Widelands::ShipStates::kExpeditionPortspaceFound) {
 		if (upcast(Widelands::Game, game, &egbase)) {
-			game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().back());
+			const Widelands::Coords portspace = ship->current_portspace();
+			assert(static_cast<bool>(portspace));
+			game->send_player_ship_construct_port(*ship, portspace);
 			return 1;
 		}
 	}

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -189,14 +189,11 @@ std::vector<Widelands::Bob*> AttackWindow::get_max_attackers() {
 				}
 			} else {  // Ship-to-land invasion
 				bool found = false;
-
-				if (building != nullptr) {
-					if (warship->sees_portspace(building->get_positions(egbase)[0])) {
-						found = true;
-						break;
-					}
+				if (building != nullptr) {  // target is a building on a port space
+					found = warship->sees_portspace(building->get_positions(egbase)[0]);
+				} else {  // target is a port space
+					found = warship->sees_portspace(target_coordinates_);
 				}
-
 				if (found) {
 					std::vector<Widelands::Soldier*> onboard = warship->onboard_soldiers();
 					result_vector.insert(result_vector.end(), onboard.begin(), onboard.end());

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -27,6 +27,7 @@
 #include "graphic/style_manager.h"
 #include "graphic/text_layout.h"
 #include "logic/map_objects/tribes/militarysite.h"
+#include "logic/map_objects/tribes/ship.h"
 #include "logic/map_objects/tribes/soldier.h"
 #include "map_io/map_object_loader.h"
 #include "map_io/map_object_saver.h"
@@ -187,18 +188,13 @@ std::vector<Widelands::Bob*> AttackWindow::get_max_attackers() {
 					result_vector.push_back(warship);
 				}
 			} else {  // Ship-to-land invasion
-				const std::vector<Widelands::Coords>& spaces = warship->exp_port_spaces();
 				bool found = false;
 
 				if (building != nullptr) {
-					for (const Widelands::Coords& coords : spaces) {
-						if (map_[coords].get_immovable() == building) {
-							found = true;
-							break;
-						}
+					if (warship->sees_portspace(building->get_positions(egbase)[0])) {
+						found = true;
+						break;
 					}
-				} else {
-					found = std::find(spaces.begin(), spaces.end(), target_coordinates_) != spaces.end();
 				}
 
 				if (found) {

--- a/src/wui/attack_window.h
+++ b/src/wui/attack_window.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include "logic/map_objects/tribes/ship.h"
 #include "logic/map_objects/tribes/soldier.h"
 #include "logic/player.h"
 #include "ui_basic/box.h"

--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -28,6 +28,7 @@
 #include "logic/cmd_queue.h"
 #include "logic/map_objects/checkstep.h"
 #include "logic/map_objects/pinned_note.h"
+#include "logic/map_objects/tribes/ship.h"
 #include "logic/map_objects/tribes/soldier.h"
 #include "logic/map_objects/tribes/tribe_descr.h"
 #include "logic/map_objects/tribes/warehouse.h"

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -598,7 +598,9 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 
 		if (f->seeing != Widelands::VisibleState::kUnexplored) {
 			// Draw build help.
-			const HasExpeditionPortSpace show_port_space = has_expedition_port_space(f->fcoords);
+			const HasExpeditionPortSpace show_port_space = map.is_port_space(f->fcoords) ?
+                                                        has_expedition_port_space(f->fcoords) :
+                                                        HasExpeditionPortSpace::kNone;
 			if (show_port_space != HasExpeditionPortSpace::kNone || suited_as_starting_pos ||
 			    buildhelp()) {
 				Widelands::NodeCaps caps;

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -397,7 +397,7 @@ InteractivePlayer::has_expedition_port_space(const Widelands::Coords& coords) co
 		if (portspace == coords) {
 			return HasExpeditionPortSpace::kPrimary;
 		}
-		if (ship->sees_portspace(portspace)) {
+		if (ship->sees_portspace(coords)) {
 			tmp_rv = HasExpeditionPortSpace::kOther;
 		}
 	}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -394,10 +394,16 @@ InteractivePlayer::has_expedition_port_space(const Widelands::Coords& coords) co
 		if (!static_cast<bool>(portspace)) {
 			continue;
 		}
-		if (portspace == coords) {
+		// Expeditions can only use the primary port space, show the others faded.
+		// Warships show all seen port spaces the same: either as usable if they are not engaged
+		// or faded otherwise.
+		if (portspace == coords && !ship->has_battle()) {
 			return HasExpeditionPortSpace::kPrimary;
 		}
 		if (ship->sees_portspace(coords)) {
+			if (ship->can_attack()) {
+				return HasExpeditionPortSpace::kPrimary;
+			}
 			tmp_rv = HasExpeditionPortSpace::kOther;
 		}
 	}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -397,7 +397,7 @@ InteractivePlayer::has_expedition_port_space(const Widelands::Coords& coords) co
 		if (pair.second.empty()) {
 			continue;
 		}
-		if (pair.second.front() == coords) {
+		if (pair.second.back() == coords) {
 			return HasExpeditionPortSpace::kPrimary;
 		}
 		if (std::find(pair.second.begin(), pair.second.end(), coords) != pair.second.end()) {

--- a/src/wui/interactive_player.h
+++ b/src/wui/interactive_player.h
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "io/profile.h"
-#include "logic/map_objects/tribes/ship.h"
 #include "logic/message_id.h"
 #include "logic/note_map_options.h"
 #include "ui_basic/button.h"
@@ -68,10 +67,6 @@ public:
 	void think() override;
 	void draw(RenderTarget& dst) override;
 
-	std::map<const Widelands::OPtr<Widelands::Ship>, std::vector<Widelands::Coords>>&
-	get_expedition_port_spaces() {
-		return expedition_port_spaces_;
-	}
 	enum class HasExpeditionPortSpace { kNone, kPrimary, kOther };
 	HasExpeditionPortSpace has_expedition_port_space(const Widelands::Coords&) const;
 
@@ -159,11 +154,7 @@ private:
 	                                       RenderTarget*,
 	                                       std::set<Widelands::Coords>&);
 
-	std::map<const Widelands::OPtr<Widelands::Ship>, std::vector<Widelands::Coords>>
-	   expedition_port_spaces_;
-
 	std::unique_ptr<Notifications::Subscriber<NoteMapOptions>> map_options_subscriber_;
-	std::unique_ptr<Notifications::Subscriber<Widelands::NoteShip>> shipnotes_subscriber_;
 };
 
 #endif  // end of include guard: WL_WUI_INTERACTIVE_PLAYER_H

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -479,7 +479,8 @@ void ShipWindow::think() {
 		 * matter if
 		 *   in waiting or already expedition/scouting mode)
 		 */
-		btn_construct_port_->set_enabled(can_act && !ship->exp_port_spaces().empty());
+		btn_construct_port_->set_enabled(can_act &&
+		                                 (state == Widelands::ShipStates::kExpeditionPortspaceFound));
 		bool coast_nearby = false;
 		for (Widelands::Direction dir = 1; dir <= Widelands::LAST_DIRECTION; ++dir) {
 			// NOTE buttons are saved in the format DIRECTION - 1

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -479,8 +479,7 @@ void ShipWindow::think() {
 		 * matter if
 		 *   in waiting or already expedition/scouting mode)
 		 */
-		btn_construct_port_->set_enabled(can_act &&
-		                                 (state == Widelands::ShipStates::kExpeditionPortspaceFound));
+		btn_construct_port_->set_enabled(can_act && !ship->exp_port_spaces().empty());
 		bool coast_nearby = false;
 		for (Widelands::Direction dir = 1; dir <= Widelands::LAST_DIRECTION; ++dir) {
 			// NOTE buttons are saved in the format DIRECTION - 1
@@ -649,7 +648,7 @@ void ShipWindow::act_construct_port() {
 		return;
 	}
 	if (Widelands::Game* game = ibase_.get_game()) {
-		game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().front());
+		game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().back());
 	} else {
 		NEVER_HERE();  // TODO(Nordfriese / Scenario Editor): implement
 	}

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -645,11 +645,12 @@ void ShipWindow::act_construct_port() {
 	if (ship == nullptr) {
 		return;
 	}
-	if (ship->exp_port_spaces().empty()) {
+	const Widelands::Coords portspace = ship->current_portspace();
+	if (!static_cast<bool>(portspace)) {
 		return;
 	}
 	if (Widelands::Game* game = ibase_.get_game()) {
-		game->send_player_ship_construct_port(*ship, ship->exp_port_spaces().back());
+		game->send_player_ship_construct_port(*ship, portspace);
 	} else {
 		NEVER_HERE();  // TODO(Nordfriese / Scenario Editor): implement
 	}


### PR DESCRIPTION
**Type of change**
Bugfix / Refactoring / Clean-up

**New behavior**
 - Warships and expedition ships use the same algorithm for updating seen portspaces
 - (restore same behaviour on spotting already known portspaces – ie. warships stop too, as in current protected/navalwarfare)
 - Don't shuffle seen portspaces when losing sight of one (more consistent display)
 - Make the last spotted portspace the target (also improves consistency)

**Possible regressions**
Anything related to portspace detection.
